### PR TITLE
fix test execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	</modules>
 
 	<properties>
-		<tycho.version>0.22.0</tycho.version>
+		<tycho.version>0.24.0</tycho.version>
 		<scala.version>2.11.7</scala.version>
 	</properties>
 

--- a/scala-ide-scaps-tests/META-INF/MANIFEST.MF
+++ b/scala-ide-scaps-tests/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Scala IDE Scaps Plugin (Test)
 Bundle-SymbolicName: scala-ide-scaps-tests
 Bundle-Version: 0.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Require-Bundle: org.junit
 Bundle-ClassPath: .,
  target/libs/scala-library-2.11.7.jar,
  target/libs/scala-reflect-2.11.7.jar,

--- a/scala-ide-scaps-tests/pom.xml
+++ b/scala-ide-scaps-tests/pom.xml
@@ -41,8 +41,7 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
-					<testSuite>${project.artifactId}</testSuite>
-					<testClass>org.scalaide.scpas.TestsSuite</testClass>
+					<testClass>org.scalaide.scaps.TestsSuite</testClass>
 				</configuration>
 			</plugin>
 

--- a/scala-ide-scaps-tests/src/org/scalaide/scaps/TestsSuite.scala
+++ b/scala-ide-scaps-tests/src/org/scalaide/scaps/TestsSuite.scala
@@ -1,8 +1,7 @@
-package org.scala.tools.eclipse.search
+package org.scalaide.scaps
 
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
-import org.scalaide.scaps.IUTest
 
 
 @RunWith(classOf[Suite])


### PR DESCRIPTION
Als Antwort auf deine Mail.

Die Versionsnummer hat wahrscheinlich keinen Einfluss, dass er den Provider nicht gefunden hatte lag sicher daran, dass keine plugin-dependency auf junit vorhanden war, und dann gabs noch ein wenig durcheinander mit den packages.
